### PR TITLE
feat: all metropolitan line stations

### DIFF
--- a/data/metropolitan.json
+++ b/data/metropolitan.json
@@ -4,102 +4,102 @@
     {
       "type": "Feature",
       "properties": { "name": "Amersham", "line": "Metropolitan" },
-      "geometry": { "type": "Point", "coordinates": [51.674125, -0.607714] }
+      "geometry": { "type": "Point", "coordinates": [-0.607714, 51.674125] }
     },
     {
       "type": "Feature",
       "properties": { "name": "Chesham", "line": "Metropolitan" },
-      "geometry": { "type": "Point", "coordinates": [51.70524, -0.611115] }
+      "geometry": { "type": "Point", "coordinates": [-0.611115, 51.70524] }
     },
     {
       "type": "Feature",
       "properties": { "name": "Chalfont & Latimer", "line": "Metropolitan" },
-      "geometry": { "type": "Point", "coordinates": [51.667983, -0.560689] }
+      "geometry": { "type": "Point", "coordinates": [-0.560689, 51.667983] }
     }, 
     {
       "type": "Feature",
       "properties": { "name": "Chorleywood", "line": "Metropolitan" },
-      "geometry": { "type": "Point", "coordinates": [51.654357, -0.518461] }
+      "geometry": { "type": "Point", "coordinates": [-0.518461, 51.654357] }
     }, 
     {
       "type": "Feature",
       "properties": { "name": "Rickmansworth", "line": "Metropolitan" },
-      "geometry": { "type": "Point", "coordinates": [51.640206, -0.473703] }
+      "geometry": { "type": "Point", "coordinates": [-0.473703, 51.640206] }
     }, 
     {
       "type": "Feature",
       "properties": { "name": "Watford", "line": "Metropolitan" },
-      "geometry": { "type": "Point", "coordinates": [51.657444, -0.417377] }
+      "geometry": { "type": "Point", "coordinates": [-0.417377, 51.657444] }
     }, 
     {
       "type": "Feature",
       "properties": { "name": "Croxley", "line": "Metropolitan" },
-      "geometry": { "type": "Point", "coordinates": [51.647042, -0.441718] }
+      "geometry": { "type": "Point", "coordinates": [-0.441718, 51.647042] }
     }, 
     {
       "type": "Feature",
       "properties": { "name": "Moor Park", "line": "Metropolitan" },
-      "geometry": { "type": "Point", "coordinates": [51.629843, -0.432454] }
+      "geometry": { "type": "Point", "coordinates": [-0.432454, 51.629843] }
     },
     {
       "type": "Feature",
       "properties": { "name": "Northwood", "line": "Metropolitan" },
-      "geometry": { "type": "Point", "coordinates": [51.611051, -0.423829] }
+      "geometry": { "type": "Point", "coordinates": [-0.423829, 51.611051] }
     },
     {
       "type": "Feature",
       "properties": { "name": "Northwood Hills", "line": "Metropolitan" },
-      "geometry": { "type": "Point", "coordinates": [51.60057, -0.409464] }
+      "geometry": { "type": "Point", "coordinates": [-0.409464, 51.60057] }
     },
     {
       "type": "Feature",
       "properties": { "name": "Pinner", "line": "Metropolitan" },
-      "geometry": { "type": "Point", "coordinates": [51.5929, -0.381161] }
+      "geometry": { "type": "Point", "coordinates": [-0.381161, 51.5929] }
     }, 
     {
       "type": "Feature",
       "properties": { "name": "North Harrow", "line": "Metropolitan" },
-      "geometry": { "type": "Point", "coordinates": [51.58487, -0.362408] }
+      "geometry": { "type": "Point", "coordinates": [-0.362408, 51.58487] }
     },
     {
       "type": "Feature",
       "properties": { "name": "Uxbridge", "line": "Metropolitan" },
-      "geometry": { "type": "Point", "coordinates": [51.546564, -0.477949] }
+      "geometry": { "type": "Point", "coordinates": [-0.477949, 51.546564] }
     },
     {
       "type": "Feature",
       "properties": { "name": "Hillingdon", "line": "Metropolitan" },
-      "geometry": { "type": "Point", "coordinates": [51.553713, -0.449828] }
+      "geometry": { "type": "Point", "coordinates": [-0.449828, 51.553713] }
     },
     {
       "type": "Feature",
       "properties": { "name": "Ickenham", "line": "Metropolitan"},
-      "geometry": { "type": "Point", "coordinates": [51.56199, -0.442001]}
+      "geometry": { "type": "Point", "coordinates": [-0.442001, 51.56199]}
     },
     {
       "type": "Feature",
       "properties": { "name": "Ruislip", "line": "Metropolitan" },
-      "geometry": { "type": "Point", "coordinates": [51.571352, -0.421898] }
+      "geometry": { "type": "Point", "coordinates": [-0.421898, 51.571352] }
     },
     {
       "type": "Feature",
       "properties": { "name": "Ruislip Manor", "line": "Metropolitan" },
-      "geometry": { "type": "Point", "coordinates": [51.573201, -0.412973] }
+      "geometry": { "type": "Point", "coordinates": [-0.412973, 51.573201] }
     },
     {
       "type": "Feature",
       "properties": { "name": "Eastcote", "line": "Metropolitan" },
-      "geometry": { "type": "Point", "coordinates": [51.576505, -0.397373] }
+      "geometry": { "type": "Point", "coordinates": [-0.397373, 51.576505] }
     },
     {
       "type": "Feature",
       "properties": { "name": "Rayners Lane", "line": "Metropolitan" },
-      "geometry": { "type": "Point", "coordinates": [51.575145, -0.371127] }
+      "geometry": { "type": "Point", "coordinates": [-0.371127, 51.575145] }
     },
     {
       "type": "Feature",
       "properties": { "name": "West Harrow", "line": "Metropolitan" },
-      "geometry": { "type": "Point", "coordinates": [51.579709, -0.3534] }
+      "geometry": { "type": "Point", "coordinates": [-0.3534, 51.579709] }
     }
   ]
 }

--- a/data/metropolitan.json
+++ b/data/metropolitan.json
@@ -100,6 +100,76 @@
       "type": "Feature",
       "properties": { "name": "West Harrow", "line": "Metropolitan" },
       "geometry": { "type": "Point", "coordinates": [-0.3534, 51.579709] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "Harrow-on-the-Hill", "line": "Metropolitan" },
+      "geometry": { "type": "Point", "coordinates": [-0.336473, 51.579245] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "Northwick Park", "line": "Metropolitan"},
+      "geometry": { "type": "Point", "coordinates": [-0.318056, 51.578479]}
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "Preston Road", "line": "Metropolitan" },
+      "geometry": { "type": "Point", "coordinates": [-0.295107, 51.57197] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "Wembley Park", "line": "Metropolitan" },
+      "geometry": { "type": "Point", "coordinates": [-0.279262, 51.563196] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "Finchley Road", "line": "Metropolitan" },
+      "geometry": { "type": "Point", "coordinates": [-0.179555, 51.546854] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "Baker Street", "line": "Metropolitan" },
+      "geometry": { "type": "Point", "coordinates": [-0.15713, 51.522881] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "Great Portland Street", "line": "Metropolitan" },
+      "geometry": { "type": "Point", "coordinates": [-0.144262, 51.523838] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "Euston Square" , "line": "Metropolitan"},
+      "geometry": { "type": "Point", "coordinates": [-0.135772, 51.525601] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "King's Cross St. Pancras", "line": "Metropolitan" },
+      "geometry": { "type": "Point", "coordinates": [-0.123195, 51.530661] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "Farringdon" , "line": "Metropolitan"},
+      "geometry": { "type": "Point", "coordinates": [-0.104828, 51.520204] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "Barbican" , "line": "Metropolitan"},
+      "geometry": { "type": "Point", "coordinates": [-0.09753, 51.520311] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "Moorgate" , "line": "Metropolitan"},
+      "geometry": { "type": "Point", "coordinates": [-0.088322, 51.518174] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "Liverpool Street", "line": "Metropolitan" },
+      "geometry": { "type": "Point", "coordinates": [-0.083182, 51.517371] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "Aldgate", "line": "Metropolitan" },
+      "geometry": { "type": "Point", "coordinates": [-0.075689, 51.514244] }
     }
   ]
 }

--- a/data/metropolitan.json
+++ b/data/metropolitan.json
@@ -1,0 +1,70 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": { "name": "Amersham", "line": "Metropolitan" },
+      "geometry": { "type": "Point", "coordinates": [51.674125, -0.607714] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "Chesham", "line": "Metropolitan" },
+      "geometry": { "type": "Point", "coordinates": [51.70524, -0.611115] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "Chalfont & Latimer", "line": "Metropolitan" },
+      "geometry": { "type": "Point", "coordinates": [51.667983, -0.560689] }
+    }, 
+    {
+      "type": "Feature",
+      "properties": { "name": "Chorleywood", "line": "Metropolitan" },
+      "geometry": { "type": "Point", "coordinates": [51.654357, -0.518461] }
+    }, 
+    {
+      "type": "Feature",
+      "properties": { "name": "Rickmansworth", "line": "Metropolitan" },
+      "geometry": { "type": "Point", "coordinates": [51.640206, -0.473703] }
+    }, 
+    {
+      "type": "Feature",
+      "properties": { "name": "Watford", "line": "Metropolitan" },
+      "geometry": { "type": "Point", "coordinates": [51.657444, -0.417377] }
+    }, 
+    {
+      "type": "Feature",
+      "properties": { "name": "Croxley", "line": "Metropolitan" },
+      "geometry": { "type": "Point", "coordinates": [51.647042, -0.441718] }
+    }, 
+    {
+      "type": "Feature",
+      "properties": { "name": "Moor Park", "line": "Metropolitan" },
+      "geometry": { "type": "Point", "coordinates": [51.629843, -0.432454] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "Northwood", "line": "Metropolitan" },
+      "geometry": { "type": "Point", "coordinates": [51.611051, -0.423829] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "Northwood Hills", "line": "Metropolitan" },
+      "geometry": { "type": "Point", "coordinates": [51.60057, -0.409464] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "Pinner", "line": "Metropolitan" },
+      "geometry": { "type": "Point", "coordinates": [51.5929, -0.381161] }
+    }, 
+    {
+      "type": "Feature",
+      "properties": { "name": "North Harrow", "line": "Metropolitan" },
+      "geometry": { "type": "Point", "coordinates": [51.58487, -0.362408] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "Uxbridge", "line": "Metropolitan" },
+      "geometry": { "type": "Point", "coordinates": [51.546564, -0.477949] }
+    }
+  ]
+}

--- a/data/metropolitan.json
+++ b/data/metropolitan.json
@@ -65,6 +65,41 @@
       "type": "Feature",
       "properties": { "name": "Uxbridge", "line": "Metropolitan" },
       "geometry": { "type": "Point", "coordinates": [51.546564, -0.477949] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "Hillingdon", "line": "Metropolitan" },
+      "geometry": { "type": "Point", "coordinates": [51.553713, -0.449828] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "Ickenham", "line": "Metropolitan"},
+      "geometry": { "type": "Point", "coordinates": [51.56199, -0.442001]}
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "Ruislip", "line": "Metropolitan" },
+      "geometry": { "type": "Point", "coordinates": [51.571352, -0.421898] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "Ruislip Manor", "line": "Metropolitan" },
+      "geometry": { "type": "Point", "coordinates": [51.573201, -0.412973] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "Eastcote", "line": "Metropolitan" },
+      "geometry": { "type": "Point", "coordinates": [51.576505, -0.397373] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "Rayners Lane", "line": "Metropolitan" },
+      "geometry": { "type": "Point", "coordinates": [51.575145, -0.371127] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "West Harrow", "line": "Metropolitan" },
+      "geometry": { "type": "Point", "coordinates": [51.579709, -0.3534] }
     }
   ]
 }


### PR DESCRIPTION
This PR includes the data for all Metropolitan line stations, using data from the Unified API. As a standard I took coordinates for each station with the area name `MET`, or `BookH` if `MET` was not listed (for example Farringdon). 

There is significant overlap with the Piccadilly line stations on the Uxbridge branch, and I was wondering if this duplication is okay? It may need to be resolved manually or perhaps implementing a system to aggregate the many stations that have multiple lines.

This PR:
- Closes #13 